### PR TITLE
The `ButtonProps` interface was being exported twice, once at its dec…

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -55,4 +55,4 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 )
 Button.displayName = 'Button'
 
-export { Button, buttonVariants, type ButtonProps }
+export { Button, buttonVariants }


### PR DESCRIPTION
…laration and again in the final export statement. This caused a build failure on Netlify due to a conflicting export error.

This change removes the redundant export from the final line, resolving the conflict.